### PR TITLE
l188 of PDFmerger, prevent fatal error

### DIFF
--- a/PDFMerger.php
+++ b/PDFMerger.php
@@ -115,7 +115,7 @@ class PDFMerger
 		}
 		else
 		{
-			if($fpdi->Output($outputpath, $mode))
+			if($fpdi->Output($outputpath, $mode) == '')
 			{
 				return true;
 			}


### PR DESCRIPTION
Prevent fatal error while executing : PHP Fatal error: Uncaught exception 'Exception' with message 'Error outputting PDF to 'file'.' in /home/runman/PDFMerger/PDFMerger.php:124
