### PR TITLE
Prevent magic_quotes in PHP 5.4+

### DIFF
--- a/fpdf/font/makefont/makefont.php
+++ b/fpdf/font/makefont/makefont.php
@@ -300,8 +300,11 @@ function CheckTTF($file)
 function MakeFont($fontfile, $afmfile, $enc='cp1252', $patch=array(), $type='TrueType')
 {
 	//Generate a font definition file
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+	if (version_compare(phpversion(), '5.4.0', '<')) {
+		if(get_magic_quotes_runtime()) {
+			@set_magic_quotes_runtime(0);
+		}
+	}
 	ini_set('auto_detect_line_endings','1');
 	if($enc)
 	{

--- a/fpdf/fpdf.php
+++ b/fpdf/fpdf.php
@@ -1069,9 +1069,12 @@ function _dochecks()
 	//Check mbstring overloading
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
-	//Disable runtime magic quotes
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+	if (version_compare(phpversion(), '5.4.0', '<')) {
+		//Disable runtime magic quotes
+		if(get_magic_quotes_runtime()) {
+			@set_magic_quotes_runtime(0);
+		}
+	}
 }
 
 function _getpageformat($format)


### PR DESCRIPTION
The use of function set_magic_quotes_runtime is discouraged in
PHP version 5.3 and forbidden in PHP version 5.4 and forbidden
in PHP version 5.5
