### PR TITLE
Error writing a file on disk during ->merge('file', 'fname.pdf')

### DIFF
--- a/PDFMerger.php
+++ b/PDFMerger.php
@@ -115,6 +115,11 @@ class PDFMerger
 		{
 			return $fpdi->Output($outputpath, 'S');
 		}
+		else if($mode == 'F')
+		{
+			$fpdi->Output($outputpath, $mode);
+			return true;
+		}
 		else
 		{
 			if($fpdi->Output($outputpath, $mode) == '')


### PR DESCRIPTION
When using 'file' method during $pdf->merge(), the function expects an output from $fpdi->Output() that will never come during output 'file' from fpdf class
I added a new case to act properly during 'file' merging mode.
