### PR TITLE
bug fix on line: '} elseif (( == '/Index') AND ([0] == PDF_TYPE_ARRAY…

### DIFF
--- a/tcpdf/tcpdi_parser.php
+++ b/tcpdf/tcpdi_parser.php
@@ -500,7 +500,7 @@ class tcpdi_parser {
             $v = $sarr[$key];
             if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
+            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count(($v[1] >= 2 ? $v[1] : '')))) {
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection


### PR DESCRIPTION
… AND count([1] >= 2')))) {', where the variable count() receives a boolean and not a numerical value.