### PR TITLE
Update tcpdi_parser.php

### DIFF
--- a/tcpdf/tcpdi_parser.php
+++ b/tcpdf/tcpdi_parser.php
@@ -500,7 +500,7 @@ class tcpdi_parser {
             $v = $sarr[$key];
             if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
+             } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1]) >= 2)) {    
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection


### PR DESCRIPTION
Changed the closure of the count to check $V[1] instead of the result of $V[1] >= 2 ... 

I did not analyze the whole code but the error COUNT only on array is gone.